### PR TITLE
docs(swagger): sync request payload descriptions

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -130,7 +130,7 @@ const docTemplate = `{
                         "required": true
                     },
                     {
-                        "description": "search permissions",
+                        "description": " ",
                         "name": "request",
                         "in": "body",
                         "required": true,
@@ -210,7 +210,7 @@ const docTemplate = `{
                         "required": true
                     },
                     {
-                        "description": "create permission",
+                        "description": " ",
                         "name": "request",
                         "in": "body",
                         "required": true,
@@ -297,7 +297,7 @@ const docTemplate = `{
                         "required": true
                     },
                     {
-                        "description": "delete permissions",
+                        "description": " ",
                         "name": "request",
                         "in": "body",
                         "required": true,
@@ -500,7 +500,7 @@ const docTemplate = `{
                         "required": true
                     },
                     {
-                        "description": "update permission",
+                        "description": " ",
                         "name": "request",
                         "in": "body",
                         "required": true,
@@ -575,7 +575,7 @@ const docTemplate = `{
                         "required": true
                     },
                     {
-                        "description": "search roles",
+                        "description": " ",
                         "name": "request",
                         "in": "body",
                         "required": true,
@@ -655,7 +655,7 @@ const docTemplate = `{
                         "required": true
                     },
                     {
-                        "description": "create role",
+                        "description": " ",
                         "name": "request",
                         "in": "body",
                         "required": true,
@@ -742,7 +742,7 @@ const docTemplate = `{
                         "required": true
                     },
                     {
-                        "description": "delete roles",
+                        "description": " ",
                         "name": "request",
                         "in": "body",
                         "required": true,
@@ -816,7 +816,7 @@ const docTemplate = `{
                         "required": true
                     },
                     {
-                        "description": "update role",
+                        "description": " ",
                         "name": "request",
                         "in": "body",
                         "required": true,
@@ -898,7 +898,7 @@ const docTemplate = `{
                         "required": true
                     },
                     {
-                        "description": "update user role",
+                        "description": " ",
                         "name": "request",
                         "in": "body",
                         "required": true,
@@ -995,7 +995,7 @@ const docTemplate = `{
                         "required": true
                     },
                     {
-                        "description": "update user",
+                        "description": " ",
                         "name": "request",
                         "in": "body",
                         "required": true,
@@ -1064,7 +1064,7 @@ const docTemplate = `{
                         "required": true
                     },
                     {
-                        "description": "login user",
+                        "description": " ",
                         "name": "request",
                         "in": "body",
                         "required": true,
@@ -1200,7 +1200,7 @@ const docTemplate = `{
                         "required": true
                     },
                     {
-                        "description": "update user",
+                        "description": " ",
                         "name": "request",
                         "in": "body",
                         "required": true,
@@ -1254,7 +1254,7 @@ const docTemplate = `{
                         "required": true
                     },
                     {
-                        "description": "register user",
+                        "description": " ",
                         "name": "request",
                         "in": "body",
                         "required": true,

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -126,7 +126,7 @@
                         "required": true
                     },
                     {
-                        "description": "search permissions",
+                        "description": " ",
                         "name": "request",
                         "in": "body",
                         "required": true,
@@ -206,7 +206,7 @@
                         "required": true
                     },
                     {
-                        "description": "create permission",
+                        "description": " ",
                         "name": "request",
                         "in": "body",
                         "required": true,
@@ -293,7 +293,7 @@
                         "required": true
                     },
                     {
-                        "description": "delete permissions",
+                        "description": " ",
                         "name": "request",
                         "in": "body",
                         "required": true,
@@ -496,7 +496,7 @@
                         "required": true
                     },
                     {
-                        "description": "update permission",
+                        "description": " ",
                         "name": "request",
                         "in": "body",
                         "required": true,
@@ -571,7 +571,7 @@
                         "required": true
                     },
                     {
-                        "description": "search roles",
+                        "description": " ",
                         "name": "request",
                         "in": "body",
                         "required": true,
@@ -651,7 +651,7 @@
                         "required": true
                     },
                     {
-                        "description": "create role",
+                        "description": " ",
                         "name": "request",
                         "in": "body",
                         "required": true,
@@ -738,7 +738,7 @@
                         "required": true
                     },
                     {
-                        "description": "delete roles",
+                        "description": " ",
                         "name": "request",
                         "in": "body",
                         "required": true,
@@ -812,7 +812,7 @@
                         "required": true
                     },
                     {
-                        "description": "update role",
+                        "description": " ",
                         "name": "request",
                         "in": "body",
                         "required": true,
@@ -894,7 +894,7 @@
                         "required": true
                     },
                     {
-                        "description": "update user role",
+                        "description": " ",
                         "name": "request",
                         "in": "body",
                         "required": true,
@@ -991,7 +991,7 @@
                         "required": true
                     },
                     {
-                        "description": "update user",
+                        "description": " ",
                         "name": "request",
                         "in": "body",
                         "required": true,
@@ -1060,7 +1060,7 @@
                         "required": true
                     },
                     {
-                        "description": "login user",
+                        "description": " ",
                         "name": "request",
                         "in": "body",
                         "required": true,
@@ -1196,7 +1196,7 @@
                         "required": true
                     },
                     {
-                        "description": "update user",
+                        "description": " ",
                         "name": "request",
                         "in": "body",
                         "required": true,
@@ -1250,7 +1250,7 @@
                         "required": true
                     },
                     {
-                        "description": "register user",
+                        "description": " ",
                         "name": "request",
                         "in": "body",
                         "required": true,

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -612,7 +612,7 @@ paths:
         name: id
         required: true
         type: string
-      - description: delete permissions
+      - description: ' '
         in: body
         name: request
         required: true
@@ -650,7 +650,7 @@ paths:
         name: Authorization
         required: true
         type: string
-      - description: search permissions
+      - description: ' '
         in: body
         name: request
         required: true
@@ -700,7 +700,7 @@ paths:
         name: Authorization
         required: true
         type: string
-      - description: create permission
+      - description: ' '
         in: body
         name: request
         required: true
@@ -800,7 +800,7 @@ paths:
         name: id
         required: true
         type: string
-      - description: update permission
+      - description: ' '
         in: body
         name: request
         required: true
@@ -894,7 +894,7 @@ paths:
         name: id
         required: true
         type: string
-      - description: delete roles
+      - description: ' '
         in: body
         name: request
         required: true
@@ -932,7 +932,7 @@ paths:
         name: Authorization
         required: true
         type: string
-      - description: search roles
+      - description: ' '
         in: body
         name: request
         required: true
@@ -982,7 +982,7 @@ paths:
         name: Authorization
         required: true
         type: string
-      - description: create role
+      - description: ' '
         in: body
         name: request
         required: true
@@ -1038,7 +1038,7 @@ paths:
         name: id
         required: true
         type: string
-      - description: update role
+      - description: ' '
         in: body
         name: request
         required: true
@@ -1089,7 +1089,7 @@ paths:
         name: Authorization
         required: true
         type: string
-      - description: update user role
+      - description: ' '
         in: body
         name: request
         required: true
@@ -1150,7 +1150,7 @@ paths:
         name: Authorization
         required: true
         type: string
-      - description: update user
+      - description: ' '
         in: body
         name: request
         required: true
@@ -1192,7 +1192,7 @@ paths:
         name: X-XSRF-TOKEN
         required: true
         type: string
-      - description: login user
+      - description: ' '
         in: body
         name: request
         required: true
@@ -1276,7 +1276,7 @@ paths:
         name: Authorization
         required: true
         type: string
-      - description: update user
+      - description: ' '
         in: body
         name: request
         required: true
@@ -1311,7 +1311,7 @@ paths:
         name: X-XSRF-TOKEN
         required: true
         type: string
-      - description: register user
+      - description: ' '
         in: body
         name: request
         required: true

--- a/internal/http/controller/admin/http_api/http_api_search.go
+++ b/internal/http/controller/admin/http_api/http_api_search.go
@@ -30,7 +30,7 @@ type HttpApiSearchData struct {
 // @accept json
 // @produce json
 // @param Authorization header string true "bearer token"
-// @param "query string" query httpapi.HttpApiSearchRequest true "search http apis"
+// @param "query string" query httpapi.HttpApiSearchRequest true " "
 // @success 200 {object} response.Response{data=httpapi.HttpApiSearchData}
 // @failure 400 {object} response.ErrorResponse "code: 400-001(Bad Request), 400-002(request validation failed)"
 // @failure 401 {object} response.ErrorResponse "code: 401-001(Unauthorized)"

--- a/internal/http/controller/admin/permission/permission_create.go
+++ b/internal/http/controller/admin/permission/permission_create.go
@@ -34,7 +34,7 @@ type PermissionCreateData struct {
 // @produce json
 // @param X-XSRF-TOKEN header string true "csrf token"
 // @param Authorization header string true "bearer token"
-// @param request body permission.PermissionCreateRequest true "create permission"
+// @param request body permission.PermissionCreateRequest true " "
 // @success 200 {object} response.Response{data=permission.PermissionCreateData}
 // @failure 400 {object} response.ErrorResponse "code: 400-001(Bad Request), 400-002(request validation failed)"
 // @failure 401 {object} response.ErrorResponse "code: 401-001(Unauthorized)"

--- a/internal/http/controller/admin/permission/permission_delete.go
+++ b/internal/http/controller/admin/permission/permission_delete.go
@@ -26,7 +26,7 @@ type PermissionDeleteRequest struct {
 // @param X-XSRF-TOKEN header string true "csrf token"
 // @param Authorization header string true "bearer token"
 // @param id path string true "id"
-// @param request body permission.PermissionDeleteRequest true "delete permissions"
+// @param request body permission.PermissionDeleteRequest true " "
 // @success 204 "no content"
 // @failure 400 {object} response.ErrorResponse "code: 400-001(Bad Request), 400-002(request validation failed)"
 // @failure 401 {object} response.ErrorResponse "code: 401-001(Unauthorized)"

--- a/internal/http/controller/admin/permission/permission_search.go
+++ b/internal/http/controller/admin/permission/permission_search.go
@@ -30,7 +30,7 @@ type PermissionSearchData struct {
 // @accept json
 // @produce json
 // @param Authorization header string true "bearer token"
-// @param request body permission.PermissionSearchRequest true "search permissions"
+// @param request body permission.PermissionSearchRequest true " "
 // @success 200 {object} response.Response{data=permission.PermissionSearchData}
 // @failure 400 {object} response.ErrorResponse "code: 400-001(Bad Request), 400-002(request validation failed)"
 // @failure 401 {object} response.ErrorResponse "code: 401-001(Unauthorized)"

--- a/internal/http/controller/admin/permission/permission_update.go
+++ b/internal/http/controller/admin/permission/permission_update.go
@@ -37,7 +37,7 @@ type PermissionUpdateData struct {
 // @param X-XSRF-TOKEN header string true "csrf token"
 // @param Authorization header string true "bearer token"
 // @param id path string true "id"
-// @param request body permission.PermissionUpdateRequest true "update permission"
+// @param request body permission.PermissionUpdateRequest true " "
 // @success 200 {object} response.Response{data=permission.PermissionUpdateData}
 // @failure 400 {object} response.ErrorResponse "code: 400-001(Bad Request), 400-002(request validation failed)"
 // @failure 401 {object} response.ErrorResponse "code: 401-001(Unauthorized)"

--- a/internal/http/controller/admin/permission/role_create.go
+++ b/internal/http/controller/admin/permission/role_create.go
@@ -25,7 +25,7 @@ type RoleCreateRequest struct {
 // @produce json
 // @param X-XSRF-TOKEN header string true "csrf token"
 // @param Authorization header string true "bearer token"
-// @param request body permission.RoleCreateRequest true "create role"
+// @param request body permission.RoleCreateRequest true " "
 // @success 200 {object} response.Response{data=permission.RoleData}
 // @failure 400 {object} response.ErrorResponse "code: 400-001(Bad Request), 400-002(request validation failed)"
 // @failure 401 {object} response.ErrorResponse "code: 401-001(Unauthorized)"

--- a/internal/http/controller/admin/permission/role_delete.go
+++ b/internal/http/controller/admin/permission/role_delete.go
@@ -24,7 +24,7 @@ type RoleDeleteRequest struct {
 // @param X-XSRF-TOKEN header string true "csrf token"
 // @param Authorization header string true "bearer token"
 // @param id path string true "id"
-// @param request body permission.RoleDeleteRequest true "delete roles"
+// @param request body permission.RoleDeleteRequest true " "
 // @success 204 "no content"
 // @failure 400 {object} response.ErrorResponse "code: 400-001(Bad Request), 400-002(request validation failed)"
 // @failure 401 {object} response.ErrorResponse "code: 401-001(Unauthorized)"

--- a/internal/http/controller/admin/permission/role_search.go
+++ b/internal/http/controller/admin/permission/role_search.go
@@ -31,7 +31,7 @@ type RoleSearchData struct {
 // @accept json
 // @produce json
 // @param Authorization header string true "bearer token"
-// @param request body permission.RoleSearchRequest true "search roles"
+// @param request body permission.RoleSearchRequest true " "
 // @success 200 {object} response.Response{data=permission.RoleSearchData}
 // @failure 400 {object} response.ErrorResponse "code: 400-001(Bad Request), 400-002(request validation failed)"
 // @failure 401 {object} response.ErrorResponse "code: 401-001(Unauthorized)"

--- a/internal/http/controller/admin/permission/role_update.go
+++ b/internal/http/controller/admin/permission/role_update.go
@@ -33,7 +33,7 @@ type RoleUpdateRequest struct {
 // @param X-XSRF-TOKEN header string true "csrf token"
 // @param Authorization header string true "bearer token"
 // @param id path string true "id"
-// @param request body permission.RoleUpdateRequest true "update role"
+// @param request body permission.RoleUpdateRequest true " "
 // @success 200 {object} response.Response{data=permission.RoleData}
 // @failure 400 {object} response.ErrorResponse "code: 400-001(Bad Request), 400-002(request validation failed)"
 // @failure 401 {object} response.ErrorResponse "code: 401-001(Unauthorized)"

--- a/internal/http/controller/admin/user/user_role_update.go
+++ b/internal/http/controller/admin/user/user_role_update.go
@@ -29,7 +29,7 @@ type UserRoleUpdateRequest struct {
 // @produce json
 // @param X-XSRF-TOKEN header string true "csrf token"
 // @param Authorization header string true "bearer token"
-// @param request body user.UserRoleUpdateRequest true "update user role"
+// @param request body user.UserRoleUpdateRequest true " "
 // @success 200 {object} response.Response{data=user.UserData}
 // @failure 400 {object} response.ErrorResponse "code: 400-001(Bad Request), 400-002(request validation failed), 400-005(permission is repeat)"
 // @failure 401 {object} response.ErrorResponse "code: 401-001(Unauthorized)"

--- a/internal/http/controller/user/user_login.go
+++ b/internal/http/controller/user/user_login.go
@@ -26,7 +26,7 @@ type UserLoginRequest struct {
 // @accept json
 // @produce json
 // @param X-XSRF-TOKEN header string true "csrf token"
-// @param request body user.UserLoginRequest true "login user"
+// @param request body user.UserLoginRequest true " "
 // @success 200 {object} response.Response{data=user.TokenData}
 // @failure 400 {object} response.ErrorResponse "code: 400-001(Bad Request), 400-002(request validation failed), 400-003(email is wrong), 400-004(password is wrong)"
 // @failure 403 {object} response.ErrorResponse "code: 403-001(Forbidden)"

--- a/internal/http/controller/user/user_register.go
+++ b/internal/http/controller/user/user_register.go
@@ -26,7 +26,7 @@ type UserRegisterRequest struct {
 // @accept json
 // @produce json
 // @param X-XSRF-TOKEN header string true "csrf token"
-// @param request body user.UserRegisterRequest true "register user"
+// @param request body user.UserRegisterRequest true " "
 // @success 200 {object} response.Response{data=user.TokenData}
 // @failure 400 {object} response.ErrorResponse "code: 400-001(Bad Request), 400-002(request validation failed)"
 // @failure 403 {object} response.ErrorResponse "code: 403-001(Forbidden)"

--- a/internal/http/controller/user/user_update.go
+++ b/internal/http/controller/user/user_update.go
@@ -23,7 +23,7 @@ type UserUpdateRequest struct {
 // @produce json
 // @param X-XSRF-TOKEN header string true "csrf token"
 // @param Authorization header string true "bearer token"
-// @param request body user.UserUpdateRequest true "update user"
+// @param request body user.UserUpdateRequest true " "
 // @success 200 {object} response.Response{data=user.UserData}
 // @failure 400 {object} response.ErrorResponse "code: 400-001(Bad Request), 400-002(request validation failed)"
 // @failure 401 {object} response.ErrorResponse "code: 401-001(Unauthorized)"

--- a/internal/http/controller/user/user_update_password.go
+++ b/internal/http/controller/user/user_update_password.go
@@ -25,7 +25,7 @@ type UserUpdatePasswordRequest struct {
 // @produce json
 // @param X-XSRF-TOKEN header string true "csrf token"
 // @param Authorization header string true "bearer token"
-// @param request body user.UserUpdatePasswordRequest true "update user"
+// @param request body user.UserUpdatePasswordRequest true " "
 // @success 204 "no content"
 // @failure 400 {object} response.ErrorResponse "code: 400-001(Bad Request), 400-002(request validation failed)"
 // @failure 401 {object} response.ErrorResponse "code: 401-001(Unauthorized)"


### PR DESCRIPTION
- replace controller @param request descriptions with blank placeholders so generated docs rely on schema names
- regenerate swagger artifacts to keep docs consistent with the updated annotations